### PR TITLE
Improve usability of the privacy option in both moderation and collaboration tab.

### DIFF
--- a/includes/profile-tab-cpublishing.php
+++ b/includes/profile-tab-cpublishing.php
@@ -27,8 +27,6 @@ function buddyforms_cpublishing_um_add_tab( $tabs ) {
 		return $tabs;
 	}
 
-	$privacy = ( ! empty( $ultimate_members_settings ) && ! empty( $ultimate_members_settings['collaborative_post_tab_privacy'] ) ) ? intval( $ultimate_members_settings['collaborative_post_tab_privacy'] ) : 3;
-
 	$tab_name = apply_filters( 'buddyforms_ultimate_member_collaborative_tab_title', __( 'Collaborative Posts', 'buddyforms-ultimate-member' ) );
 	if ( ! empty( $ultimate_members_settings['collaborative_post_tab_name'] ) ) {
 		$tab_name = $ultimate_members_settings['collaborative_post_tab_name'];
@@ -38,10 +36,6 @@ function buddyforms_cpublishing_um_add_tab( $tabs ) {
 		'name' => $tab_name,
 		'icon' => 'um-faicon-gift',
 	);
-
-	if ( $privacy !== 5 ) {
-		$args['default_privacy'] = $privacy;
-	}
 
 	$tabs['buddyforms_cpublishing'] = $args;
 

--- a/includes/profile-tab-moderators.php
+++ b/includes/profile-tab-moderators.php
@@ -26,8 +26,6 @@ function buddyforms_moderators_um_add_tab( $tabs ) {
 		return $tabs;
 	}
 
-	$privacy = ( ! empty( $ultimate_members_settings ) && ! empty( $ultimate_members_settings['moderation_tab_privacy'] ) ) ? intval( $ultimate_members_settings['moderation_tab_privacy'] ) : 3;
-
 	$tab_name = apply_filters( 'buddyforms_ultimate_member_moderation_tab_title', __( 'Moderate Posts', 'buddyforms-ultimate-member' ) );
 	if ( ! empty( $ultimate_members_settings['moderation_tab_name'] ) ) {
 		$tab_name = $ultimate_members_settings['moderation_tab_name'];
@@ -39,12 +37,7 @@ function buddyforms_moderators_um_add_tab( $tabs ) {
 		'custom' => true,
 	);
 
-	if ( $privacy !== 5 ) {
-		$args['default_privacy'] = $privacy;
-	}
-
 	$tabs['buddyforms_moderation'] = $args;
-
 
 	return $tabs;
 }

--- a/includes/ultimate-member-settings.php
+++ b/includes/ultimate-member-settings.php
@@ -89,19 +89,11 @@ function buddyforms_ultimate_members_admin_tab_page( $tab ) {
 									<input type="text" style="max-width: 25rem" name="buddyforms_ultimate_settings[moderation_tab_name]" id="buddyforms_ultimate_settings_moderation_tab_name" value="<?php echo esc_attr( $ultimate_members_settings['moderation_tab_name'] ) ?>">
 								</td>
 							</tr>
-							<tr valign="top">
-								<th scope="row" class="titledesc">
-									<label for="buddyforms_ultimate_settings_moderation_tab_privacy"><?php _e( 'Moderation Tab Privacy', 'buddyforms-ultimate-member' ); ?></label>
+
+							<tr>
+								<th colspan="2">
+									<small><?php echo sprintf( __( 'For more privacy option check inside the UM Profile Member <a target="_blank" href="%s">here!</a>', 'buddyforms-ultimate-member' ), get_admin_url( get_current_blog_id(), 'admin.php?page=um_options&tab=appearance&section=profile_menu' ) ) ?> </small>
 								</th>
-								<td class="forminp forminp-select">
-									<select name="buddyforms_ultimate_settings[moderation_tab_privacy]" id="buddyforms_ultimate_settings_moderation_tab_privacy">
-										<?php foreach ( $privacy as $privacy_key => $privacy_name ) : ?>
-											<option value="<?php echo $privacy_key ?>" <?php selected( $privacy_key, $ultimate_members_settings['moderation_tab_privacy'] ); ?> ><?php echo $privacy_name ?></option>
-										<?php endforeach; ?>
-									</select>
-									<br/>
-									<small><?php echo sprintf( __( 'For more privacy option check inside the UM Profile Member <a target="_blank" href="%s">here!</a>', 'buddyforms-ultimate-member' ), get_admin_url( get_current_blog_id(), 'admin.php?page=um_options&tab=appearance&section=profile_menu' ) ) ?></small>
-								</td>
 							</tr>
 
 							<tr>
@@ -131,19 +123,11 @@ function buddyforms_ultimate_members_admin_tab_page( $tab ) {
 									<input type="text" style="max-width: 25rem" name="buddyforms_ultimate_settings[collaborative_post_tab_name]" id="buddyforms_ultimate_settings_moderation_tab_name" value="<?php echo esc_attr( $ultimate_members_settings['collaborative_post_tab_name'] ) ?>">
 								</td>
 							</tr>
-							<tr valign="top">
-								<th scope="row" class="titledesc">
-									<label for="buddyforms_ultimate_settings_moderation_tab_privacy"><?php _e( 'Collaborative Tab Privacy', 'buddyforms-ultimate-member' ); ?></label>
+
+							<tr>
+								<th colspan="2">
+									<small><?php echo sprintf( __( 'For more privacy option check inside the UM Profile Member <a target="_blank" href="%s">here!</a>', 'buddyforms-ultimate-member' ), get_admin_url( get_current_blog_id(), 'admin.php?page=um_options&tab=appearance&section=profile_menu' ) ) ?> </small>
 								</th>
-								<td class="forminp forminp-select">
-									<select name="buddyforms_ultimate_settings[collaborative_post_tab_privacy]" id="buddyforms_ultimate_settings_moderation_tab_privacy">
-										<?php foreach ( $privacy as $privacy_key => $privacy_name ) : ?>
-											<option value="<?php echo $privacy_key ?>" <?php selected( $privacy_key, $ultimate_members_settings['collaborative_post_tab_privacy'] ); ?> ><?php echo $privacy_name ?></option>
-										<?php endforeach; ?>
-									</select>
-									<br/>
-									<small><?php echo sprintf( __( 'For more privacy option check inside the UM Profile Member <a target="_blank" href="%s">here!</a>', 'buddyforms-ultimate-member' ), get_admin_url( get_current_blog_id(), 'admin.php?page=um_options&tab=appearance&section=profile_menu' ) ) ?></small>
-								</td>
 							</tr>
 
 							</tbody>


### PR DESCRIPTION
Basically, I did remove the unnecessary privacy selector on the BuddyForms settings a just set a link to the option on UM Profile Member, take a look at the image below:

Before
![image](https://user-images.githubusercontent.com/36063539/99867634-74841e80-2b91-11eb-80f0-955bb18f8cd5.png)

After
![image](https://user-images.githubusercontent.com/36063539/99867638-7bab2c80-2b91-11eb-95b9-e55aeac81dc7.png)
